### PR TITLE
check the env vars to decide where to get fetchConfig

### DIFF
--- a/src/slices/configSlice.js
+++ b/src/slices/configSlice.js
@@ -18,43 +18,39 @@ const initialState = {
   retries: 0,
 }
 
-// fetch config via origin
-export const fetchConfig = createAsyncThunk(
-  'config/getConfig',
-  async (_, thunkAPI) => {
-    try {
-      const options = { baseUrl, authUrl }
-      const api = new OpenTenderAPI(options)
-      // for testing
-      // const response = await api.getHttpResponse(503)
-      const response = await api.getConfig()
-      const brandId = response.brand.brandId
-      const clientId = response.clientId
-      const app = { baseUrl, authUrl, clientId, brandId }
-      return { ...response, app }
-    } catch (err) {
-      return thunkAPI.rejectWithValue(err)
-    }
-  }
-)
+const clientId = process.env.REACT_APP_CLIENT_ID
+const brandId = process.env.REACT_APP_BRAND_ID
 
-// fetch config via explicit brandId and clientId
-// const clientId = process.env.REACT_APP_CLIENT_ID
-// const brandId = process.env.REACT_APP_BRAND_ID
-// export const fetchConfig = createAsyncThunk(
-//   'config/getConfig',
-//   async (_, thunkAPI) => {
-//     try {
-//       const options = { baseUrl, authUrl, clientId, brandId }
-//       const api = new OpenTenderAPI(options)
-//       const response = await api.getConfig()
-//       const app = { baseUrl, authUrl, clientId, brandId }
-//       return { ...response, app }
-//     } catch (err) {
-//       return thunkAPI.rejectWithValue(err)
-//     }
-//   }
-// )
+export const fetchConfig =
+  clientId && brandId
+    ? // fetch config via explicit brandId and clientId
+      createAsyncThunk('config/getConfig', async (_, thunkAPI) => {
+        try {
+          const options = { baseUrl, authUrl, clientId, brandId }
+          const api = new OpenTenderAPI(options)
+          const response = await api.getConfig()
+          const app = { baseUrl, authUrl, clientId, brandId }
+          return { ...response, app }
+        } catch (err) {
+          return thunkAPI.rejectWithValue(err)
+        }
+      })
+    : // fetch config via origin
+      createAsyncThunk('config/getConfig', async (_, thunkAPI) => {
+        try {
+          const options = { baseUrl, authUrl }
+          const api = new OpenTenderAPI(options)
+          // for testing
+          // const response = await api.getHttpResponse(503)
+          const response = await api.getConfig()
+          const brandId = response.brand.brandId
+          const clientId = response.clientId
+          const app = { baseUrl, authUrl, clientId, brandId }
+          return { ...response, app }
+        } catch (err) {
+          return thunkAPI.rejectWithValue(err)
+        }
+      })
 
 const configSlice = createSlice({
   name: 'config',


### PR DESCRIPTION
A helpful change I could use when i'm developing, saves me from having to keep stashing / unstashing / commenting the section in `configSlice.js`

figured i'd slice off a PR